### PR TITLE
Support ignoring particular files in `@path`.

### DIFF
--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -59,13 +59,14 @@ struct Path <: AbstractString
         ctx = SHA.SHA1_CTX()
         for (root, _, fs) in walkdir(dir), f in fs
             fullpath = joinpath(root, f)
-            if !should_ignore(fullpath, ignore)
+			rel = relpath(fullpath, dir)
+            if !should_ignore(rel, ignore)
                 if is_dir || path == fullpath
                     include_dependency(fullpath)
                     SHA.update!(ctx, codeunits(fullpath))
                     content = read(fullpath)
                     SHA.update!(ctx, content)
-                    files[relpath(fullpath, dir)] = content
+                    files[rel] = content
                 end
             end
         end

--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -59,7 +59,7 @@ struct Path <: AbstractString
         ctx = SHA.SHA1_CTX()
         for (root, _, fs) in walkdir(dir), f in fs
             fullpath = joinpath(root, f)
-			rel = relpath(fullpath, dir)
+            rel = relpath(fullpath, dir)
             if !should_ignore(rel, ignore)
                 if is_dir || path == fullpath
                     include_dependency(fullpath)

--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -75,7 +75,7 @@ end
 
 should_ignore(path::AbstractString, ::Nothing) = false
 should_ignore(path::AbstractString, matcher::Function) = matcher(path)
-should_ignore(path::AbstractString, re::Regex) = !isnothing(match(re, path))
+should_ignore(path::AbstractString, re::Regex) = match(re, path) !== nothing
 should_ignore(path::AbstractString, res::Vector{Regex}) = any((should_ignore(path, re) for re in res))
 should_ignore(path::AbstractString, other) = error("unsupported argument type given for ignore.")
 

--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -23,7 +23,7 @@ function safe_ispath(file)
 end
 
 """
-    @path expr
+    @path expr [ignore]
 
 Define a "relocatable" path. Its contents will be available regardless of
 whether the original path still exists or not. The contents of the path is
@@ -31,11 +31,15 @@ stored within the returned `Path` object and the folder structure is recreated
 as a scratchspace if the original does not exist anymore. Calling any path
 manipulation functions, such as `joinpath`, on the `Path` will return a path
 to a valid folder.
+
+`ignore` can be used to skip reading in matching files. It can be a `Regex`,
+`Vector{Regex}`, or a single argument `Function` that takes the path and returns
+`true` if it should be ignored, `false` otherwise.
 """
-macro path(expr)
+macro path(expr, ignore = :nothing)
     file = string(__source__.file)
     dir = safe_isfile(file) ? dirname(file) : pwd()
-    return :($(Path)($__module__, $dir, $(esc(expr))))
+    return :($(Path)($__module__, $dir, $(esc(expr)), $(esc(ignore))))
 end
 
 struct Path <: AbstractString
@@ -45,7 +49,7 @@ struct Path <: AbstractString
     hash::String
     files::Dict{String,Vector{UInt8}}
 
-    function Path(mod::Module, dir, path::AbstractString)
+    function Path(mod::Module, dir, path::AbstractString, ignore = nothing)
         path = isabspath(path) ? path : joinpath(dir, path)
         path = normpath(path)
         safe_ispath(path) || throw(ArgumentError("not a path: `$path`"))
@@ -55,17 +59,25 @@ struct Path <: AbstractString
         ctx = SHA.SHA1_CTX()
         for (root, _, fs) in walkdir(dir), f in fs
             fullpath = joinpath(root, f)
-            if is_dir || path == fullpath
-                include_dependency(fullpath)
-                SHA.update!(ctx, codeunits(fullpath))
-                content = read(fullpath)
-                SHA.update!(ctx, content)
-                files[relpath(fullpath, dir)] = content
+            if !should_ignore(fullpath, ignore)
+                if is_dir || path == fullpath
+                    include_dependency(fullpath)
+                    SHA.update!(ctx, codeunits(fullpath))
+                    content = read(fullpath)
+                    SHA.update!(ctx, content)
+                    files[relpath(fullpath, dir)] = content
+                end
             end
         end
         return new(is_dir, mod, dir, string(Base.SHA1(SHA.digest!(ctx))), files)
     end
 end
+
+should_ignore(path::AbstractString, ::Nothing) = false
+should_ignore(path::AbstractString, matcher::Function) = matcher(path)
+should_ignore(path::AbstractString, re::Regex) = !isnothing(match(re, path))
+should_ignore(path::AbstractString, res::Vector{Regex}) = any((should_ignore(path, re) for re in res))
+should_ignore(path::AbstractString, other) = error("unsupported argument type given for ignore.")
 
 Base.show(io::IO, path::Path) = print(io, repr(getroot(path)))
 Base.ncodeunits(f::Path) = ncodeunits(getpath(f))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ const IGNORE_RE = @path "path" r".md$"
 const IGNORE_RE_REL = @path "path" r"^subfolder"
 const IGNORE_RES = @path "path" [r".md$"]
 const IGNORE_FN = @path "path" path -> endswith(path, ".md")
-const IGNORE_FN_REL = @path "path" !startswith("file")
+const IGNORE_FN_REL = @path "path" path -> !startswith(path, "file")
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,11 +10,6 @@ const OTHER = @path joinpath(DIR, "subfolder/other.jl") # issue 8
 const IGNORE_RE = @path "path" r".md$"
 const IGNORE_RES = @path "path" [r".md$"]
 const IGNORE_FN = @path "path" path -> endswith(path, ".md")
-const IGNORE_ERR = try
-    @path "path" 123
-catch e
-    e
-end
 
 end
 
@@ -44,7 +39,6 @@ end
         @test !haskey(M.IGNORE_RES.files, joinpath("path", "text.md"))
         @test length(M.IGNORE_FN.files) == 2
         @test !haskey(M.IGNORE_FN.files, joinpath("path", "text.md"))
-        @test IGNORE_ERR isa Exception
     end
     from, to = joinpath.(Ref(@__DIR__), ("path", "moved"))
     try
@@ -81,6 +75,8 @@ end
         tests()
         @test String(M.DIR) == joinpath(@__DIR__, "path")
         @test String(M.FILE) == joinpath(@__DIR__, "path", "file.jl")
+
+        @test_throws(ErrorException, @path("path", 123))
     finally
         isdir(from) || mv(to, from)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,10 @@ const DIR = @path "path"
 const FILE = @path joinpath("path", "file.jl")
 const OTHER = @path joinpath(DIR, "subfolder/other.jl") # issue 8
 const IGNORE_RE = @path "path" r".md$"
+const IGNORE_RE_REL = @path "path" r"^subfolder"
 const IGNORE_RES = @path "path" [r".md$"]
 const IGNORE_FN = @path "path" path -> endswith(path, ".md")
+const IGNORE_FN_REL = @path "path" !startswith("file")
 
 end
 
@@ -35,10 +37,15 @@ end
 
         @test length(M.IGNORE_RE.files) == 2
         @test !haskey(M.IGNORE_RE.files, joinpath("path", "text.md"))
+        @test length(M.IGNORE_RE_REL.files) == 2
+        @test !haskey(M.IGNORE_RE_REL.files, joinpath("path", "text.md"))
+        @test !haskey(M.IGNORE_RE_REL.files, joinpath("path", "file.jl"))
         @test length(M.IGNORE_RES.files) == 2
         @test !haskey(M.IGNORE_RES.files, joinpath("path", "text.md"))
         @test length(M.IGNORE_FN.files) == 2
         @test !haskey(M.IGNORE_FN.files, joinpath("path", "text.md"))
+        @test length(M.IGNORE_FN_REL.files) == 1
+        @test !haskey(M.IGNORE_FN_REL.files, joinpath("path", "file.jl"))
     end
     from, to = joinpath.(Ref(@__DIR__), ("path", "moved"))
     try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,9 @@ using RelocatableFolders
 const DIR = @path "path"
 const FILE = @path joinpath("path", "file.jl")
 const OTHER = @path joinpath(DIR, "subfolder/other.jl") # issue 8
+const IGNORE_RE = @path "path" r".md$"
+const IGNORE_RES = @path "path" [r".md$"]
+const IGNORE_FN = @path "path" path -> endswith(path, ".md")
 
 end
 
@@ -29,6 +32,13 @@ end
         @test length(M.DIR.files) == 3
         @test M.DIR.mod == M
         @test M.DIR.path == joinpath(@__DIR__, "path")
+
+        @test length(M.IGNORE_RE.files) == 2
+        @test !haskey(M.IGNORE_RE.files, joinpath("path", "text.md"))
+        @test length(M.IGNORE_RES.files) == 2
+        @test !haskey(M.IGNORE_RES.files, joinpath("path", "text.md"))
+        @test length(M.IGNORE_FN.files) == 2
+        @test !haskey(M.IGNORE_FN.files, joinpath("path", "text.md"))
     end
     from, to = joinpath.(Ref(@__DIR__), ("path", "moved"))
     try


### PR DESCRIPTION
@fonsp, @dralletje this might be helpful for those source map files that were getting included in Pluto's relocatable folders. Just ignore the source map files and we might improve load time, at the cost of not having source maps in relocated images with Pluto. Let me know if it speeds things up.