### PR TITLE
Add path to scratch key

### DIFF
--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -89,7 +89,7 @@ Base.String(f::Path) = String(getpath(f))
 
 function getpath(f::Path)
     safe_ispath(f.path) && return getroot(f)
-    dir = Scratch.get_scratch!(f.mod, f.hash * "_" * string(Base.SHA1(SHA.sha1(f.path))))
+    dir = Scratch.get_scratch!(f.mod, f.hash * "_" * string(hash(f.path), base=62))
     if !isempty(f.files) && !safe_ispath(joinpath(dir, first(keys(f.files))))
         cd(dir) do
             for (file, blob) in f.files

--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -89,7 +89,7 @@ Base.String(f::Path) = String(getpath(f))
 
 function getpath(f::Path)
     safe_ispath(f.path) && return getroot(f)
-    dir = Scratch.get_scratch!(f.mod, f.hash)
+    dir = Scratch.get_scratch!(f.mod, f.hash * f.path)
     if !isempty(f.files) && !safe_ispath(joinpath(dir, first(keys(f.files))))
         cd(dir) do
             for (file, blob) in f.files

--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -89,7 +89,7 @@ Base.String(f::Path) = String(getpath(f))
 
 function getpath(f::Path)
     safe_ispath(f.path) && return getroot(f)
-    dir = Scratch.get_scratch!(f.mod, f.hash * "_" * string(Base.SHA1(sha1(f.path))))
+    dir = Scratch.get_scratch!(f.mod, f.hash * "_" * string(Base.SHA1(SHA.sha1(f.path))))
     if !isempty(f.files) && !safe_ispath(joinpath(dir, first(keys(f.files))))
         cd(dir) do
             for (file, blob) in f.files

--- a/src/RelocatableFolders.jl
+++ b/src/RelocatableFolders.jl
@@ -89,7 +89,7 @@ Base.String(f::Path) = String(getpath(f))
 
 function getpath(f::Path)
     safe_ispath(f.path) && return getroot(f)
-    dir = Scratch.get_scratch!(f.mod, f.hash * f.path)
+    dir = Scratch.get_scratch!(f.mod, f.hash * "_" * string(Base.SHA1(sha1(f.path))))
     if !isempty(f.files) && !safe_ispath(joinpath(dir, first(keys(f.files))))
         cd(dir) do
             for (file, blob) in f.files


### PR DESCRIPTION
I have a package that uses RelocatableFolders. Currently, (I suspect that) if I run two versions of the package (say, a release, and then a local clone from `Pkg.develop`) with the same (hash of the) contents of the relocatable folder, then both versions will point to *the same* folder, in the first version that ran. This is because we the key to `get_scratch!` is just the content hash.

Besides a wrong stacktrace, this is not really a problem in most cases (because the two folders have the same contents), but it does cause a problem when the contents of the local clone change (e.g. when switching branches) after the package was loaded. 

This came up here: https://github.com/fonsp/Pluto.jl/issues/1965#issuecomment-1059318361 , where I suspect this happened, although we did not test it. I think that the result from `@path` in the local clone points to the path in the release (because at load time, their contents were equal).

The solution in this PR is based on https://github.com/JuliaPackaging/Scratch.jl/tree/v1.1.0#can-i-create-a-scratch-space-that-is-not-shared-across-versions-of-my-package . (Which surprised me, I assumed this was the default.) The path is hashed to avoid illegal characters in the key.